### PR TITLE
2021-11-19

### DIFF
--- a/Client/윈플기말/ObjectManager.cpp
+++ b/Client/윈플기말/ObjectManager.cpp
@@ -465,7 +465,6 @@ int initObject(OBJECT* obj, int mapnum, HINSTANCE g_hinst)
 //카메라 무빙워크
 void adjustCamera(CAMERA& camera, PLAYER player)
 {
-	std::cout << camera.getx() << ", " << camera.gety() << std::endl;
 	//플레이어의 머리부분이 카메라의 꼭대기점을 넘어가면 바로 따라붙게한다
 	if (player.gety() - player.geth() < camera.gety())
 	{

--- a/Client/윈플기말/player.cpp
+++ b/Client/윈플기말/player.cpp
@@ -890,7 +890,6 @@ void PLAYER::draw(HDC& mem1dc, HDC& pdc, int x, int y, int h, int stealth, int s
 			TransparentBlt(gdidc, 0, 0, 62, 50, pdc, 0, 50, 62, 50, RGB(255, 255, 255));
 			if (stealth > 0)
 			{
-
 				bf.SourceConstantAlpha = 155;//투명도
 				//이 함수는 일반 stretchblt 와 비슷하다 gdidc 는 최대가 0,0 ~62,50 이므로 뒷 인자는 0 0 62 50
 				GdiAlphaBlend(mem1dc, x - charw, y - h, charw * 2, h * 2, gdidc, 0, 0, 62, 50, bf);
@@ -898,7 +897,9 @@ void PLAYER::draw(HDC& mem1dc, HDC& pdc, int x, int y, int h, int stealth, int s
 
 			}
 			else
+			{
 				GdiAlphaBlend(mem1dc, x - charw, y - h, charw * 2, h * 2, gdidc, 0, 0, 62, 50, bf);
+			}
 		}
 
 	}
@@ -926,7 +927,6 @@ void PLAYER::draw(HDC& mem1dc, HDC& pdc, int x, int y, int h, int stealth, int s
 			TransparentBlt(gdidc, 0, 0, 62, 50, pdc, bx * 68, by + 50, bw, bh, RGB(255, 255, 255));
 			if (stealth > 0)
 			{
-
 				bf.SourceConstantAlpha = 155;//투명도
 				//이 함수는 일반 stretchblt 와 비슷하다 gdidc 는 최대가 0,0 ~62,50 이므로 뒷 인자는 0 0 62 50
 				GdiAlphaBlend(mem1dc, x - charw, y - h, charw * 2, h * 2, gdidc, 0, 0, 62, 50, bf);
@@ -934,7 +934,9 @@ void PLAYER::draw(HDC& mem1dc, HDC& pdc, int x, int y, int h, int stealth, int s
 
 			}
 			else
+			{
 				GdiAlphaBlend(mem1dc, x - charw, y - h, charw * 2, h * 2, gdidc, 0, 0, 62, 50, bf);
+			}
 		}
 
 

--- a/Protocol/protocol.h
+++ b/Protocol/protocol.h
@@ -11,6 +11,7 @@ const char CS_PACKET_LOGIN = 1;
 const char CS_PACKET_MOVE = 2;
 const char CS_PACKET_SCENE_CHANGE = 3;
 const char CS_PACKET_GAMEJOIN = 4;
+const char CS_PACKET_KEYUP = 5;
 
 const char CS_PACKET_ROBBY = 98;
 const char CS_PACKET_TEST = 99;
@@ -37,6 +38,12 @@ struct cs_packet_move {
 	unsigned char size;
 	char	type;
 	char	dir;			// 0 : up,  1: down, 2:left, 3:right, 4:jump
+};
+
+struct cs_packet_keyup {
+	unsigned char size;
+	char type;
+	char vk_key;
 };
 
 struct cs_packet_test {

--- a/Server/CLIENT/Client.cpp
+++ b/Server/CLIENT/Client.cpp
@@ -72,9 +72,8 @@ void Client::ProcessPacket(unsigned char* p)
 	case CS_PACKET_MOVE: {
 		cs_packet_move* packet = reinterpret_cast<cs_packet_move*>(p);
 
-
 		switch ((int)packet->dir) {
-		case 37: //VK_LEFT
+		case VK_LEFT: //VK_LEFT
 			//std::cout << "left" << std::endl;
 			LEFTkey = true;
 			if (RIGHTkey == true)
@@ -91,7 +90,7 @@ void Client::ProcessPacket(unsigned char* p)
 			{
 				if (state == 1)
 				{
-				state = 4;
+					state = 4;
 					dir = 1;
 
 				}
@@ -99,14 +98,14 @@ void Client::ProcessPacket(unsigned char* p)
 					state = 4;
 					dir = 1;
 				}
-				COMMAND_move = 1;	
-				
+				COMMAND_move = 1;
+
 			}
 			else if (state == 2)
 			{
-				if (COMMAND_hurt != 1)	
-					ROWSPEED = ROWSPEED/3;
-				dir = 1;	
+				if (COMMAND_hurt != 1)
+					ROWSPEED = 150;
+				dir = 1;
 			}
 			else if (state == 3)
 			{
@@ -122,18 +121,18 @@ void Client::ProcessPacket(unsigned char* p)
 				dir = 1;
 			}
 			break;
-		case 39: //VK_RIGHT
-			RIGHTkey = true;	
+		case VK_RIGHT: //VK_RIGHT
+			RIGHTkey = true;
 			if (LEFTkey == true)
 			{
 				LRkey = true;
-				if (state == 4)		
+				if (state == 4)
 					state = 1;
 				return;
 			}
 			if (state == 7)
 			{
-				dir = 2;	
+				dir = 2;
 			}
 			else if (state == 1 || state == 4)
 			{
@@ -148,14 +147,14 @@ void Client::ProcessPacket(unsigned char* p)
 					dir = 2;
 
 				}
-				COMMAND_move = 2;	
-				
+				COMMAND_move = 2;
+
 			}
 			else if (state == 2)
 			{
-				if (COMMAND_hurt != 1)	
-					ROWSPEED = ROWSPEED/3;
-				dir = 2;	
+				if (COMMAND_hurt != 1)
+					ROWSPEED = 150;
+				dir = 2;
 			}
 			else if (state == 3)
 			{
@@ -171,7 +170,7 @@ void Client::ProcessPacket(unsigned char* p)
 				//COMMAND_move = 2;
 			}
 			break;
-		case 38: //VK_UP
+		case VK_UP: //VK_UP
 			UPkey = true;
 
 			if (DOWNkey == true)
@@ -188,7 +187,7 @@ void Client::ProcessPacket(unsigned char* p)
 
 			}
 			break;
-		case 40: //VK_DOWN
+		case VK_DOWN: //VK_DOWN
 			if (COMMAND_hurt == 1)
 				return;
 			DOWNkey = true;
@@ -216,12 +215,12 @@ void Client::ProcessPacket(unsigned char* p)
 			}
 			else if (state == 1) {
 
-				state = 3;	
-				h -= 12;		
+				state = 3;
+				h -= 12;
 				y += 12;
 			}
 			break;
-		case 32: //VK_SPACE
+		case VK_SPACE: //VK_SPACE
 			//std::cout << "space bar " << std::endl;
 			if (DOWNkey == true)
 			{
@@ -229,32 +228,39 @@ void Client::ProcessPacket(unsigned char* p)
 			}
 			if (state == 5 || state == 8)
 			{
-				if (LRkey == 0)		
+				if (LRkey == 0)
 				{
-					if (LEFTkey == 1 || RIGHTkey == 1)	
+					if (LEFTkey == 1 || RIGHTkey == 1)
 					{
 						COMMAND_move = dir;
-						jumpignore = 2;	
+						jumpignore = 2;
 					}
 					else return;
 				}
 				else return;
 			}
-			if (state != 2 && state != 7)	
+			if (state != 2 && state != 7)
 			{
 				//Sound::GetSelf()->Sound_Play(EFFECTSOUND, JUMPEF, EFVOL);
-				falldy = 10;	
+				falldy = 10;
 				jumpcount++;
 				state = 2;
 				savey = y;
 			}
 			break;
 
-		case 47: //left keyUp
-			if (RIGHTkey == true)		
+		}
+		break;
+	}
+	case CS_PACKET_KEYUP: {
+		cs_packet_keyup* packet = reinterpret_cast<cs_packet_keyup*>(p);
+		switch (packet->vk_key)
+		{
+		case VK_LEFT: //left keyUp
+			if (RIGHTkey == true)
 			{
 				dir = 2;
-				if (state == 1)			
+				if (state == 1)
 					COMMAND_move = 2;
 			}
 			else if (RIGHTkey == false)
@@ -262,15 +268,15 @@ void Client::ProcessPacket(unsigned char* p)
 				if (state == 4)
 				{
 					state = 1;
-					COMMAND_move = 0;	
+					COMMAND_move = 0;
 				}
-				else if (state == 1)	
+				else if (state == 1)
 				{
 					COMMAND_move = 0;
 				}
 				if (DOWNkey == true)
 				{
-					if (state == 1)	
+					if (state == 1)
 					{
 						state = 3;
 						h -= 12;
@@ -280,30 +286,30 @@ void Client::ProcessPacket(unsigned char* p)
 			}
 
 
-			LRkey = false;				
-			LEFTkey = false;			
+			LRkey = false;
+			LEFTkey = false;
 			break;
-		case 49: //right keyUp
-			if (LEFTkey == true)		
+		case VK_RIGHT: //right keyUp
+			if (LEFTkey == true)
 			{
 				dir = 1;
-				if (state == 1)			
+				if (state == 1)
 					COMMAND_move = 1;
 			}
-			else if (LEFTkey == false)	
+			else if (LEFTkey == false)
 			{
 				if (state == 4)
 				{
 					state = 1;
-					COMMAND_move = 0;	
+					COMMAND_move = 0;
 				}
-				else if (state == 1)	
+				else if (state == 1)
 				{
 					COMMAND_move = 0;
 				}
 				if (DOWNkey == true)
 				{
-					if (state == 1)	
+					if (state == 1)
 					{
 						state = 3;
 						h -= 12;
@@ -312,13 +318,13 @@ void Client::ProcessPacket(unsigned char* p)
 				}
 			}
 
-			LRkey = false;				
-			RIGHTkey = false;			
+			LRkey = false;
+			RIGHTkey = false;
 			break;
-		case 48: //up keyUp
+		case VK_UP: //up keyUp
 			if (DOWNkey == true)
 			{
-				if (state == 5)			
+				if (state == 5)
 					COMMAND_move = 4;
 			}
 			else if (DOWNkey == false)
@@ -326,27 +332,27 @@ void Client::ProcessPacket(unsigned char* p)
 				if (state == 8)
 				{
 					state = 5;
-					COMMAND_move = 0;	
+					COMMAND_move = 0;
 				}
 			}
 
 			UPkey = false;
 			UDkey = false;
 			break;
-		case 50: //down keyDown
+		case VK_DOWN: //down keyDown
 			if (UPkey == true)
 			{
-				if (state == 5)			
+				if (state == 5)
 					COMMAND_move = 3;
 			}
-			else if (UPkey == false)	
+			else if (UPkey == false)
 			{
 				if (state == 8)
 				{
 					state = 5;
-					COMMAND_move = 0;	
+					COMMAND_move = 0;
 				}
-				else if (state == 5)	
+				else if (state == 5)
 				{
 					COMMAND_move = 0;
 				}
@@ -356,7 +362,7 @@ void Client::ProcessPacket(unsigned char* p)
 				if (state == 3)
 				{
 					h += 12;
-					y -= 12;	
+					y -= 12;
 					state = 1;
 				}
 			}
@@ -364,10 +370,7 @@ void Client::ProcessPacket(unsigned char* p)
 			UDkey = false;
 			DOWNkey = false;
 			break;
-		}
-		//case 42: //spacebar keyUp
-		//	
-		//	break;
+		}		
 		break;
 	}
 	case CS_PACKET_GAMEJOIN: {

--- a/Server/CLIENT/GameClient.cpp
+++ b/Server/CLIENT/GameClient.cpp
@@ -34,9 +34,16 @@ void GameClient::update(float delta_time)
 	BitMove();
 
 	//send packet
-	sc_packet_empty packet;
-	packet.size = sizeof(sc_packet_empty);
-	packet.type = SC_PACKET_EMPTY;
+	sc_packet_move_process packet;
+	packet.size = sizeof(sc_packet_move_process);
+	packet.type = SC_PACKET_MOVE_PROCESS;
+	packet.dir = dir;
+	packet.h = h;
+	packet.id = c_id;
+	packet.state = state;
+	packet.stealth = stealth;
+	packet.x = x;
+	packet.y = y;
 	do_send(&packet, sizeof(packet));
 
 	Client::update(delta_time);
@@ -112,12 +119,11 @@ void GameClient::move(int obj_t, float deltatime)
 		{
 			if (COMMAND_move == 1)
 			{
-
-				x -= ROWSPEED * deltatime;
+				x -= (int)(ROWSPEED * deltatime);
 			}
 			else if (COMMAND_move == 2)
 			{
-				x += ROWSPEED * deltatime;
+				x += (int)(ROWSPEED * deltatime);
 			}
 			//y -= 1;
 			if (abs(y - savey) > 40) {
@@ -137,11 +143,11 @@ void GameClient::move(int obj_t, float deltatime)
 			if (COMMAND_move == 1)
 			{
 
-				x -= ROWSPEED * deltatime;
+				x -= (int)(ROWSPEED * deltatime);
 			}
 			else if (COMMAND_move == 2)
 			{
-				x += ROWSPEED * deltatime;
+				x += (int)(ROWSPEED * deltatime);
 			}
 
 
@@ -149,11 +155,10 @@ void GameClient::move(int obj_t, float deltatime)
 				falldy -= GroundAccel;
 			if (falldy < 0)
 			{
-				std::cout << "state7로 change" << std::endl;
+				//std::cout << "state7로 change" << std::endl;
 				state = 7;
 			}
 			y -= falldy;
-			std::cout << "y = " << y << std::endl;
 		}
 
 
@@ -177,11 +182,13 @@ void GameClient::move(int obj_t, float deltatime)
 
 			if (COMMAND_move == 1)
 			{
-				x -= ROWSPEED * deltatime;
+				x -= (int)(ROWSPEED * deltatime);
+				
 			}
 			else if (COMMAND_move == 2)
 			{
-				x += ROWSPEED * deltatime;
+				x += (int)(ROWSPEED * deltatime);
+				
 			}
 		}
 	}
@@ -225,25 +232,23 @@ void GameClient::move(int obj_t, float deltatime)
 			adjustspd++;
 		if (LEFTkey == true)
 			if (adjustspd % 30 == 0)
-				x -= ROWSPEED * deltatime;
+				x -= (int)(ROWSPEED * deltatime);
 		if (RIGHTkey == true)
 			if (adjustspd % 30 == 0)
-				x += ROWSPEED * deltatime;
+				x += (int)(ROWSPEED * deltatime);
 		if (COMMAND_move == 1)
 		{
 			if (adjustspd <= 10)
-			{
-				x -= ROWSPEED * deltatime;
-			}
+				x -= (int)(ROWSPEED * deltatime);
 			if (adjustspd > 10)
 			{
 				if (adjustspd % 2 == 0)
-					x -= ROWSPEED * deltatime;
+					x -= (int)(ROWSPEED * deltatime);
 			}
 			else if (adjustspd > 30)
 			{
 				if (adjustspd % 5 == 0)
-					x -= ROWSPEED * deltatime;
+					x -= (int)(ROWSPEED * deltatime);
 			}
 
 			if (LEFTkey == 0)
@@ -255,17 +260,17 @@ void GameClient::move(int obj_t, float deltatime)
 		{
 			if (adjustspd <= 10)
 			{
-				x += ROWSPEED * deltatime;
+				x += (int)(ROWSPEED * deltatime);
 			}
 			if (adjustspd > 10)
 			{
 				if (adjustspd % 2 == 0)
-					x += ROWSPEED * deltatime;
+					x += (int)(ROWSPEED * deltatime);
 			}
 			else if (adjustspd > 30)
 			{
 				if (adjustspd % 5 == 0)
-					x += ROWSPEED * deltatime;
+					x += (int)(ROWSPEED * deltatime);
 			}
 			if (RIGHTkey == 0)
 				if (abs(x - savex) > 50)
@@ -429,8 +434,8 @@ void GameClient::adjustPlayer()
 					COMMAND_hurt = 0;			//땅에 닿았으면 피격아님
 					COMMAND_ropehurt = 0;		//땅에 닿았으면 피격아님
 
-					//if (ROWSPEED != 3)		//ROWSPEED를 임의로 바꿔주었다면 땅에 닿으면 초기화니 원래대로 돌려준다
-					//	ROWSPEED = 3;
+					if (ROWSPEED != 150)		//ROWSPEED를 임의로 바꿔주었다면 땅에 닿으면 초기화니 원래대로 돌려준다
+						ROWSPEED = 150;
 				}
 
 				if (obj->type == 4)
@@ -498,8 +503,8 @@ void GameClient::adjustPlayer()
 						COMMAND_hurt = 0;			//땅에 닿았으면 피격아님
 						COMMAND_ropehurt = 0;		//땅에 닿았으면 피격아님
 
-						//if (ROWSPEED != 3)		//ROWSPEED를 임의로 바꿔주었다면 땅에 닿으면 초기화니 원래대로 돌려준다
-						//	ROWSPEED = 3;
+						if (ROWSPEED != 150)		//ROWSPEED를 임의로 바꿔주었다면 땅에 닿으면 초기화니 원래대로 돌려준다
+							ROWSPEED = 150;
 					}
 					//X Collapse
 					if (state == 1 || state == 4) //Walking Collpse
@@ -689,8 +694,8 @@ void GameClient::adjustPlayer()
 			{
 
 			}
-			//if (ROWSPEED != 3)		//ROWSPEED를 임의로 바꿔주었다면 땅에 닿으면 초기화니 원래대로 돌려준다
-			//	ROWSPEED = 3; 잠깐 위로 올려줬음 주석처리하고 ㅇㅇ 근데 이게 맞을거같긴해
+			if (ROWSPEED != 150)		//ROWSPEED를 임의로 바꿔주었다면 땅에 닿으면 초기화니 원래대로 돌려준다
+				ROWSPEED = 150;			//잠깐 위로 올려줬음 주석처리하고 ㅇㅇ 근데 이게 맞을거같긴해
 
 			//return;			//하나라도 부딪혔다면 그대로 탈출한다
 		}

--- a/Server/CLIENT/LobbyClient.cpp
+++ b/Server/CLIENT/LobbyClient.cpp
@@ -27,8 +27,7 @@ void LobbyClient::update(float delta_time)
 		
 	
 		elapsedtime = 0;
-		std::cout << "로비클라" << std::endl;
-		//std::cout << "로비클라" << robby_timer << "초" << std::endl;
+		//std::cout << "로비클라" << std::endl;
 		
 		if (robby_cnt == 1)
 		{
@@ -72,11 +71,20 @@ void LobbyClient::update(float delta_time)
 	obj_t += 1;
 	move(obj_t, delta_time);
 	BitMove();
+	adjustPlayer();
 	//timer();
 	//send packet
-	sc_packet_empty packet;
-	packet.size = sizeof(sc_packet_empty);
-	packet.type = SC_PACKET_EMPTY;
+
+	sc_packet_move_process packet;
+	packet.size = sizeof(sc_packet_move_process);
+	packet.type = SC_PACKET_MOVE_PROCESS;
+	packet.dir = dir;
+	packet.h = h;
+	packet.id = c_id;
+	packet.state = state;
+	packet.stealth = stealth;
+	packet.x = x;
+	packet.y = y;
 	do_send(&packet, sizeof(packet));
 
 	Client::update(delta_time);
@@ -162,17 +170,18 @@ void LobbyClient::move(int obj_t, float deltatime)
 	}
 	else if (state == 2)
 	{
-		//std::cout << "state2" << std::endl;
 		if (COMMAND_hurt == true)
 		{
 			if (COMMAND_move == 1)
 			{
 
-				x -= ROWSPEED * deltatime;
+				std::cout << "1번깎임" << std::endl;
+				x -= (int)(ROWSPEED * deltatime);
 			}
 			else if (COMMAND_move == 2)
 			{
-				x += ROWSPEED * deltatime;
+				
+				x += (int)(ROWSPEED * deltatime);
 			}
 			//y -= 1;
 			if (abs(y - savey) > 40) {
@@ -191,12 +200,11 @@ void LobbyClient::move(int obj_t, float deltatime)
 		{
 			if (COMMAND_move == 1)
 			{
-
-				x -= ROWSPEED * deltatime;
+				x -= (int)(ROWSPEED * deltatime);
 			}
 			else if (COMMAND_move == 2)
 			{
-				x += ROWSPEED * deltatime;
+				x += ROWSPEED  * deltatime;
 			}
 
 
@@ -204,22 +212,19 @@ void LobbyClient::move(int obj_t, float deltatime)
 				falldy -= GroundAccel;
 			if (falldy < 0)
 			{
-				std::cout << "state7로 change" << std::endl;
+				//std::cout << "state7로 change" << std::endl;
 				state = 7;
 			}
 			y -= falldy;
-			std::cout << "y = " << y << std::endl;
 		}
 
 
 	}
 	else if (state == 3)
 	{
-		//std::cout << "state3" << std::endl;
 	}
 	else if (state == 4)
 	{
-		//std::cout << "state4" << std::endl;
 		if (LRkey == true)
 		{
 
@@ -232,17 +237,16 @@ void LobbyClient::move(int obj_t, float deltatime)
 
 			if (COMMAND_move == 1)
 			{
-				x -= ROWSPEED * deltatime;
+				x -= (int)(ROWSPEED * deltatime);
 			}
 			else if (COMMAND_move == 2)
 			{
-				x += ROWSPEED * deltatime;
+				x += (int)(ROWSPEED * deltatime);
 			}
 		}
 	}
 	else if (state == 5)
 	{
-		//std::cout << "state5" << std::endl;
 		savey = y;
 		if (UDkey == true)
 		{
@@ -263,7 +267,6 @@ void LobbyClient::move(int obj_t, float deltatime)
 	}
 	else if (state == 6)
 	{
-		//std::cout << "state6" << std::endl;
 		ROWSPEED *= 3;
 		stealth = 100;
 		savey = y;
@@ -273,32 +276,36 @@ void LobbyClient::move(int obj_t, float deltatime)
 	}
 	else if (state == 7)
 	{
-		//std::cout << "state7들어옴" << std::endl;
 		y += COLSPEED;
-		//std::cout << y << std::endl;
 		if (adjustspd < 1000)
 			adjustspd++;
 		if (LEFTkey == true)
 			if (adjustspd % 30 == 0)
-				x -= ROWSPEED * deltatime;
+			{
+				x -= (int)(ROWSPEED * deltatime);
+			}
 		if (RIGHTkey == true)
 			if (adjustspd % 30 == 0)
-				x += ROWSPEED * deltatime;
+				x += (int)(ROWSPEED * deltatime);
 		if (COMMAND_move == 1)
 		{
 			if (adjustspd <= 10)
 			{
-				x -= ROWSPEED * deltatime;
+				x -= (int)(ROWSPEED * deltatime);
 			}
 			if (adjustspd > 10)
 			{
 				if (adjustspd % 2 == 0)
-					x -= ROWSPEED * deltatime;
+				{
+					x -= (int)(ROWSPEED * deltatime);
+				}
 			}
 			else if (adjustspd > 30)
 			{
 				if (adjustspd % 5 == 0)
-					x -= ROWSPEED * deltatime;
+				{
+					x -= (int)(ROWSPEED * deltatime);
+				}
 			}
 
 			if (LEFTkey == 0)
@@ -310,17 +317,17 @@ void LobbyClient::move(int obj_t, float deltatime)
 		{
 			if (adjustspd <= 10)
 			{
-				x += ROWSPEED * deltatime;
+				x += (int)(ROWSPEED * deltatime);
 			}
 			if (adjustspd > 10)
 			{
 				if (adjustspd % 2 == 0)
-					x += ROWSPEED * deltatime;
+					x += (int)(ROWSPEED * deltatime);
 			}
 			else if (adjustspd > 30)
 			{
 				if (adjustspd % 5 == 0)
-					x += ROWSPEED * deltatime;
+					x += (int)(ROWSPEED * deltatime);
 			}
 			if (RIGHTkey == 0)
 				if (abs(x - savex) > 50)
@@ -350,4 +357,418 @@ void LobbyClient::move(int obj_t, float deltatime)
 			}
 		}
 	}
+}
+
+
+
+//오브젝트와 플레이어 충돌체크 1이면 부닥침
+//----------------------------------------
+bool LobbyClient::collp2o(Object* Obj)
+{
+
+	int adjust = 10;
+	//왜 101이 먼저오냐면 발판보다는 장애물이 우선순위기때문임
+	if (101 <= Obj->type && Obj->type < 301) { //장애물일때는 플레이어 네모빡스가 히트박스가된다
+		if (Obj->type == 106 || Obj->type == 107)
+		{
+			if (x + w < Obj->x + Obj->mx || x - w > Obj->x + Obj->mx + Obj->w) return 0;
+			if (y + h < Obj->y + Obj->my || y - h > Obj->y + Obj->my + Obj->h) return 0;
+		}
+		else
+		{
+			if (x + w < Obj->x || x - w > Obj->x + Obj->w) return 0;
+			if (y + h < Obj->y || y - h > Obj->y + Obj->h) return 0;
+		}
+
+
+		return 1;
+	}
+	else if (301 <= Obj->type && Obj->type < 401)	//로프,밧줄같은 딱코 맞춰야하는 오브젝 위로는 플레이어 발까지 닿아야하고 아래로는 플레이어 중점에서 끝난다 하지만 내려갈수도 있어야하므로 조금 후하게 준다
+	{
+
+		if (y + h < Obj->y || y - h > Obj->y + Obj->h) return 0;	//일단먼저 닿았으면 들어와
+
+		if (Obj->x < x && x < Obj->x + Obj->w)	//파이프가 그래도 좀 두꺼우니 이안에들어오면 cehck
+		{
+			if (UPkey == true)//여기는 특이하게 올라가면 올라가는쪽 체크는 끝이나야한다.
+			{
+
+				if (y + h <= Obj->y)	//올라갔을때 아랫키를 만족하면 충돌체크 x 안그러면 반응해서 계속 줄에매달리는 오류
+					return 0;
+				if (y < Obj->y + Obj->h)
+					return 1;
+			}
+			else if (DOWNkey == true)
+			{
+
+				if (y + h <= Obj->y)
+					return 1;
+			}
+
+			if (y + h <= Obj->y || y < Obj->y + Obj->h)
+				return 1;
+		}
+
+		return 0;
+	}
+	else if (Obj->type == 1)	//땅바닥일때
+	{
+		if (Obj->x <= x && x <= Obj->x + Obj->w)
+		{
+			if (Obj->y <= y + h)
+			{
+				return 1;
+			}
+		}
+	}
+	else if (Obj->type <= 100) {	//플랫폼일때는 플레이어 중점이 히트박스가된다
+		if (Obj->x <= x && x <= Obj->x + Obj->w)
+		{
+			if (Obj->y <= y + h && y + h <= Obj->y + adjust)
+			{
+				return 1;
+				//ㅇㅇ
+			}
+		}
+	}
+
+	return 0;
+}
+
+
+
+//플레이어와 오브젝트간 상호작용 판단하고 그에맞게 바꿔줌
+void LobbyClient::adjustPlayer()
+{
+	int check_coll = 0;	//하나라도 부딪혔는지 판별하기위함
+	if (x - w < 0)
+	{
+		x = w;
+		COMMAND_move = 0;
+	}
+	else if (x + w > 1023)
+	{
+		x = 1023 - w;
+		COMMAND_move = 0;
+	}
+
+	for (auto& obj : mMap->mObjects[mStageNum])
+	{
+		if (collp2o(obj))
+		{
+			//std::cout << "부딪힘" << std::endl;
+			check_coll++;	//하나라도 부딪혔으면 coll이 올라감
+			if (obj->type < 101 && obj->type > 0)			//근데 그게 땅바닥이였다?
+			{
+
+				if (state == 7) //떨어지는 중일때 부딪혔다 ?
+				{
+					if (abs(savey - y) > 200)	//낙뎀을받아야한다면
+					{
+						if (stealth == 0)	//무적이 아니라면
+						{
+							COMMAND_move = dir;//보고있는방향으로 앞으로 나가게, 떨어졌는데 가만히있진 않지요
+							state = 6;//피격으로감
+							//player.hurt();
+							return;
+						}
+					}
+					y = (obj->y - h);//발판위로 y좌표 세팅해주고
+
+					if (LEFTkey == 0 && RIGHTkey == 0)	//근데 그와중에도 아무키도 안누르고있었다 ? 
+						COMMAND_move = false;	//그럼 진행방향으로 가는걸 멈추도록해준다.
+					else if (LEFTkey == 1 && RIGHTkey == 1)
+						COMMAND_move = false;	//동시에 누르고있었어도 멈춰준다
+					else if (LEFTkey == 1)	//하지만 뭔가를 누르고있었다?
+						COMMAND_move = 1;
+					else if (RIGHTkey == 1)			//그에맞춰바꿔준다
+						COMMAND_move = 2;
+
+					if (DOWNkey == true) {
+						state = 3;	//숙이고있던 상태였다면 계속 숙이고있어줌
+						y = y + 12;
+						h = h - 12;	//계산이 끝났다면 다시 숙이기상태로 돌려줌
+					}
+					else state = 1;				//숙이던게 아니였으면 땅에부딪혔으니 정지상태해줌
+					adjustspd = 0;			//떨어질때가속도를 위한거니 이것도 정지해줌
+					COMMAND_hurt = 0;			//땅에 닿았으면 피격아님
+					COMMAND_ropehurt = 0;		//땅에 닿았으면 피격아님
+
+					if (ROWSPEED != 150)		//ROWSPEED를 임의로 바꿔주었다면 땅에 닿으면 초기화니 원래대로 돌려준다
+						ROWSPEED = 150;
+				}
+
+				if (obj->type == 4)
+				{
+					//x = x + beltspeed;
+				}
+				if (obj->type == 6)
+				{
+					//x = x - beltspeed;
+				}
+			}
+			else if (obj->type >= 101 && obj->type <= 200)	//장애물에 부딪히면
+			{
+
+				if (obj->type == 101)	//까시라면
+				{
+					if (stealth == 0)	//무적이 아니라면
+					{
+						if (state == 5 || state == 8)
+						{
+							COMMAND_ropehurt = 1;
+						}
+						if (state == 3) //숙이고있었다면
+						{
+							y = y - 12;
+							h = h + 12;
+							//계산전에 돌려놓고 시작한다. 이건 땅에 닿을시점에 다시돌려준다
+						}
+						if (state == 7)//일반일때는 살짝 점프 뛰듯이 가는데 떨어지는중이면 살짝만 이동한다
+						{
+							if (COMMAND_move == 1)
+							{
+								spike_hurt = -8;	//8번 왼쪽으로 감
+							}
+							else if (COMMAND_move == 2)
+							{
+								spike_hurt = 8;	//8번 오른쪽으로감
+							}
+
+							stealth = 100;	//무적시간 넣어줌 (이동하는로직은 state==7 일때 알아서 다뤄줌
+						}
+						else {
+							state = 6;		//피격으로감
+						}
+						//player.hurt();
+					}
+				}
+				else if (obj->type == 102) //Break Pipe Left
+				{
+					if (state == 7) //떨어지는 중일때 부딪혔다 ?
+					{
+						y = obj->y - h;//발판위로 y좌표 세팅해주고
+
+						if (LEFTkey == 0 && RIGHTkey == 0)	//근데 그와중에도 아무키도 안누르고있었다 ? 
+							COMMAND_move = false;	//그럼 진행방향으로 가는걸 멈추도록해준다.
+						else if (LEFTkey == 1 && RIGHTkey == 1)
+							COMMAND_move = false;	//동시에 누르고있었어도 멈춰준다
+						else if (LEFTkey == 1)	//하지만 뭔가를 누르고있었다?
+							COMMAND_move = 1;
+						else if (RIGHTkey == 1)			//그에맞춰바꿔준다
+							COMMAND_move = 2;
+
+						state = 1;				//그리고 땅에부딪혔으니 정지상태해줌
+						adjustspd = 0;			//떨어질때가속도를 위한거니 이것도 정지해줌
+						COMMAND_hurt = 0;			//땅에 닿았으면 피격아님
+						COMMAND_ropehurt = 0;		//땅에 닿았으면 피격아님
+
+						if (ROWSPEED != 150)		//ROWSPEED를 임의로 바꿔주었다면 땅에 닿으면 초기화니 원래대로 돌려준다
+							ROWSPEED = 150;
+					}
+					//X Collapse
+					if (state == 1 || state == 4) //Walking Collpse
+					{
+						if (obj->y < y - h)
+						{
+							if (obj->x < x + w) //Left Collpse
+							{
+								x = obj->x - w;// x좌표 세팅해주고
+								COMMAND_move = 0;//Don't Move
+							}
+						}
+					}
+				}
+				else if (obj->type == 103) //왼쪽 증기, 가시와 비슷함 대신 증기가 완전히 뿜어져  나왔을때 피격판정이 있다.
+				{
+					if (obj->index == 2) //증기가 완전히 뿜어졌을때만 피격이 발생한다
+					{
+						if (stealth == 0)
+						{
+							if (state == 5 || state == 8)
+							{
+								COMMAND_ropehurt = 1;
+							}
+							if (state == 3) //숙이고있었다면
+							{
+								y = y - 12;
+								h = h + 12;	//계산전에 돌려놓고 시작한다. 이건 땅에 닿을시점에 다시돌려준다
+							}
+							if (state == 7)
+							{
+								if (dir == 1 || dir == 2) //무조건 왼쪽으로감
+								{
+									spike_hurt = -8;
+								}
+								stealth = 100;
+							}
+							else {
+								COMMAND_move = 1;//무조건 왼쪽임
+								state = 6;
+							}
+							//player.hurt();
+						}
+					}
+				}
+				else if (obj->type == 104) //Break Pipe Right
+				{
+					//Update Cooming Soon
+				}
+				else if (obj->type == 105) //Gas Right
+				{
+					//Update Cooming Soon
+				}
+				else if (obj->type == 106)
+				{
+					if (stealth == 0)	//무적이 아니라면
+					{
+						if (state == 5 || state == 8)
+						{
+							COMMAND_ropehurt = 1;
+						}
+						if (state == 3) //숙이고있었다면
+						{
+							y = y - 12;
+							h = h + 12;
+							//계산전에 돌려놓고 시작한다. 이건 땅에 닿을시점에 다시돌려준다
+						}
+						if (state == 7)//일반일때는 살짝 점프 뛰듯이 가는데 떨어지는중이면 살짝만 이동한다
+						{
+							if (dir == 1)
+							{
+								spike_hurt = -8;	//8번 왼쪽으로 감
+							}
+							else if (dir == 2)
+							{
+								spike_hurt = 8;	//8번 오른쪽으로감
+							}
+
+							stealth = 100;	//무적시간 넣어줌 (이동하는로직은 state==7 일때 알아서 다뤄줌
+						}
+						else {
+							COMMAND_move = dir;
+							state = 6;		//피격으로감
+						}
+						//player.hurt();
+					}
+				}
+				else if (obj->type == 107)
+				{
+					if (stealth == 0)	//무적이 아니라면
+					{
+						if (state == 5 || state == 8)
+						{
+							COMMAND_ropehurt = 1;
+						}
+						if (state == 3) //숙이고있었다면
+						{
+							y = y - 12;
+							h = h + 12;
+							//계산전에 돌려놓고 시작한다. 이건 땅에 닿을시점에 다시돌려준다
+						}
+						if (state == 7)//일반일때는 살짝 점프 뛰듯이 가는데 떨어지는중이면 살짝만 이동한다
+						{
+							if (dir == 1)
+							{
+								spike_hurt = -8;	//8번 왼쪽으로 감
+							}
+							else if (dir == 2)
+							{
+								spike_hurt = -8;	//8번 오른쪽으로감
+							}
+
+							stealth = 100;	//무적시간 넣어줌 (이동하는로직은 state==7 일때 알아서 다뤄줌
+						}
+						else {
+							COMMAND_move = dir;
+							state = 6;		//피격으로감
+						}
+						//player.hurt();
+					}
+				}
+			}
+			else if (obj->type >= 201 && obj->type <= 300) //플레이어와 상호작용하는 오브젝트 ex)포탈
+			{
+				if (obj->type == 201) //Portal
+				{
+					if (UPkey == true)
+					{
+						//맵이 바뀌는 로직 
+
+						//m.setblack_t(50);
+						///*m.CreateBlack(g_hinst);*/
+						//m.setmapnum(m.getmapnum() + 1);
+						////saveMapNum = m.getmapnum();
+						//player.initPos();
+						//if (m.getmapnum() == 13) {
+						//
+						//	m.CreateMap(g_hinst);
+						//
+						//}
+						//
+						//for (int j = 0; j < mObjectCount; j++)
+						//	obj[j].ResetObject();
+						//mObjectCount = initObject(obj, m.getmapnum(), g_hinst);
+						//m.CreateMap(g_hinst);
+						//
+						//
+						//Sound::GetSelf()->setindex(m.getmapnum() - 9);
+						//Sound::GetSelf()->Sound_Play(BGMSOUND, Sound::GetSelf()->getindex(), BGMVOL);
+						//Sound::GetSelf()->Sound_Play(EFFECTSOUND, PORTALEF, EFVOL);
+						//
+						//return;
+					}
+				}
+			}
+			else if (obj->type == 301) //Rope
+			{
+				if (jumpignore <= 0)
+				{
+					if (COMMAND_ropehurt == 0)	//로프에서 맞으면 다시 로프 못탐
+					{
+						if (UPkey == true || DOWNkey == true)
+						{
+							if (DOWNkey == true && (state == 2 || state == 7))	//공중에있거나 점프중일때 아랫키로는 줄에 붙을수없다
+								return;
+
+							if (state != 5 && state != 8)	//줄에 매달려있지 않았다면 줄에 매달리는 상태를 만들어준다. 이미붙어있다면 해줄필요없음
+							{
+								state = 5;
+								if (UPkey == true)
+									COMMAND_move = 3;
+								if (DOWNkey == true)
+									COMMAND_move = 4;
+								x = obj->x + (obj->w / 2);
+								if (DOWNkey == true)	//이때는 수그리기아니라 밧줄 아래로 내려가는것이므로 수그리기로 깍인거 돌려준다
+								{
+									y = y - 12;
+									h = 25;
+								}
+							}
+							//player.BitMove();
+						}
+					}
+				}
+			}
+			else if (obj->type == 0)
+			{
+
+			}
+			if (ROWSPEED != 150)		//ROWSPEED를 임의로 바꿔주었다면 땅에 닿으면 초기화니 원래대로 돌려준다
+				ROWSPEED = 150; //잠깐 위로 올려줬음 주석처리하고 ㅇㅇ 근데 이게 맞을거같긴해
+
+			//return;			//하나라도 부딪혔다면 그대로 탈출한다
+		}
+	}
+
+	if (check_coll != 0)
+		return;	//하나라도 부딪혔다면 그대로 탈출
+	if ((state == 4 || state == 1) || (state == 5 || state == 8))	//하나도 못부딪혔으면 공중에있는거니까 떨어져야한다
+	{
+		state = 7;
+		//player.fall2save();		//떨어지는 순간의 x좌표점 기억
+	}
+
+
+
 }

--- a/Server/CLIENT/LobbyClient.h
+++ b/Server/CLIENT/LobbyClient.h
@@ -25,4 +25,6 @@ public:
 
 	bool is_robby = false;
 
+	bool collp2o(class Object* Obj);
+	void adjustPlayer();
 };

--- a/Server/main.cpp
+++ b/Server/main.cpp
@@ -38,6 +38,7 @@ void ChangeLoginToRobby(const int& c_id)
 	*Upcasting_changed = *Upcasted_original;
 	willbe_changed->elapsedtime = 0;
 	willbe_changed->mStageNum = 0;
+	willbe_changed->mMap = mainMap;
 	willbe_changed->initBitPos();
 	willbe_changed->initPos();
 	CLIENTS[my_id] = willbe_changed;


### PR DESCRIPTION
작업자 : 이수민
작업내용 :
 - 기존의 윈플 input은 한번 눌리고 다음 누른걸 판정하기까지의 시간이 있기 때문에, keyboard 변수를 추가하여 update에서 input을 날려주는 형식으로 변경
 - 기타 알아먹기 힘든 숫자들 VK_식으로 변경
 - 키보드 눌림과 뗌 한번에 계산하던걸 분리(단순히 + 10 해줘서 누름과 뗌을 구분한다면, VK이벤트중 다른것과 겹쳐서 버그가 날 가능성이 존재함), 그 과정에서 패킷이 추가됨.
 - 기존의 lobby와 ingame에서 empty 패킷을 보내는것에서 이제 유의미한 데이터를 가지는 move_process패킷을 보내는것으로 변경 login은 여전히 empty 패킷을 보냄.
 - lobby에서 adjustPlayer 로직을 추가
 - 프레임을 통한 이동속도를 위해서, ROWSPEED * deltatime을 해주었는데, x,y좌표는 int이고 변화량은 float형식이라 float->int사이에서 벌어지는 버림현상이 +와 -에서 유의미한 데이터값을 가져서 변화량을 int로 캐스팅
 기존의 클라에 있던 ROWSPEED = 1 로직을 3->1로 즉 3분의 1로 이해하여 ROWSPEED = ROWSPEED / 3 으로 했던것 수정. 나누기로 한다면 매 프레임마다 나눠져서 0이 되버린다. 의도는 그게 아닌데.. 그러나 이것 또한 문제가 있어 현재 150으로 고정.
 - 로비에서 mMap이 등록되지않아 Map을 못 불러오는 현상 수정
 -