### PR TITLE
2021 11 23

### DIFF
--- a/Server/CLIENT/Client.cpp
+++ b/Server/CLIENT/Client.cpp
@@ -31,7 +31,7 @@ Client::Client()
 	SceneChangeTrigger = CreateEvent(NULL, FALSE, FALSE, NULL);
 	SceneChangeIsDone = CreateEvent(NULL, FALSE, FALSE, NULL);
 
-	key_seperate = CreateEvent(NULL, FALSE, TRUE, NULL);
+	//CountSendController = CreateEvent(NULL, FALSE, TRUE, NULL);
 
 	//
 	//bx = 0;

--- a/Server/CLIENT/Client.h
+++ b/Server/CLIENT/Client.h
@@ -59,7 +59,7 @@ public:
 	Scene_Name mSn;
 	HANDLE SceneChangeTrigger;
 	HANDLE SceneChangeIsDone;
-	HANDLE key_seperate;
+	HANDLE CountSendController;
 	SOCKET c_socket;
 	bool is_active;
 	int c_id;

--- a/Server/CLIENT/LobbyClient.cpp
+++ b/Server/CLIENT/LobbyClient.cpp
@@ -32,6 +32,7 @@ void LobbyClient::update(float delta_time)
 
 		if (robby_cnt == 2)
 		{
+
 			robby_timer--;
 			if (robby_timer < 0) {
 				//mCss = CSS_DEAD;
@@ -58,6 +59,7 @@ void LobbyClient::update(float delta_time)
 				mCss = CSS_DEAD;
 				mSn = SN_INGAME;
 				SetEvent(SceneChangeTrigger);
+
 			}
 
 			for (int i = 0; i < robby_cnt; ++i) {
@@ -68,6 +70,7 @@ void LobbyClient::update(float delta_time)
 				packet.countdown = robby_timer;
 				
 				CLIENTS[i]->do_send(&packet, sizeof(packet));
+
 			}
 			
 		}

--- a/Server/CLIENT/LobbyClient.h
+++ b/Server/CLIENT/LobbyClient.h
@@ -23,7 +23,7 @@ public:
 	void initPos();
 
 	int robby_timer;
-	int robby_cnt = 0;
+	
 
 	bool is_robby = false;
 

--- a/Server/Network.cpp
+++ b/Server/Network.cpp
@@ -7,6 +7,7 @@
 std::array<class Client*, 3> CLIENTS;
 Network* Network::mNetwork = nullptr;
 int Cnt_Player = 0;
+int robby_cnt = 0;
 
 void error_display(int err_no)
 {

--- a/Server/Network.h
+++ b/Server/Network.h
@@ -4,6 +4,7 @@
 
 extern std::array<class Client*, 3> CLIENTS;
 extern int Cnt_Player;
+extern int robby_cnt;
 
 void error_display(int err_no);
 class Network

--- a/Server/main.cpp
+++ b/Server/main.cpp
@@ -179,6 +179,7 @@ DWORD WINAPI GameLogicThread(LPVOID arg)
 				// mCss가 바뀌고 mSn이 바뀌기 전에(순서가 존재함) 이 아래 코드를 실행하면 동기화문제가 생기니
 				// Event를 사용하여 동기화문제를 해결한다.
 				WaitForSingleObject(c->SceneChangeTrigger, INFINITE);
+
 				switch (c->mSn)
 				{
 				case SN_LOBBY:
@@ -186,8 +187,10 @@ DWORD WINAPI GameLogicThread(LPVOID arg)
 					ChangeLoginToRobby(c->c_id);
 					c->mCss = CSS_LIVE;
 					auto lc = reinterpret_cast<LobbyClient*>(c);
-					lc->robby_cnt = Cnt_Player;
-					//cout << "lc로비카운트는"<<lc->robby_cnt << endl;
+					//WaitForSingleObject(lc->CountSendController, INFINITE);
+
+					robby_cnt += 1;
+					//cout << "lc로비카운트는"<<robby_cnt << endl;
 
 					SetEvent(c->SceneChangeIsDone);
  					break;
@@ -303,6 +306,8 @@ int main()
 	HANDLE hThread;
 	HANDLE LogicThread;
 	LogicThread = CreateThread(NULL, 0, GameLogicThread, 0, 0, NULL);
+
+
 	for (int i = 0; i < 3; ++i,++Cnt_Player)
 	{
 		CLIENTS[i]->c_socket = mNet->AcceptClient(CLIENTS[i]->c_addr);


### PR DESCRIPTION
작업자: 박주용
작업내용: robby 카운트다운 오류 수정
- 기존 오류: 플레이어가 한명씩 따로따로 로그인->로비 입장 시 문제없이 동시에 카운트가 시작되고 게임으로 들어가지만 플레이들이 모두 서버에 connect되어 있는 상태에서 한명이라도 로비로 입장시 모든 플레이어가 로비에 들어온 것으로 처리되어 타이머가 시작되었고 나머지 플레이어도 로비 입장 시 카운트다운이 화면에 겹쳐서 10 9 8 7 10 9 6 8 5 7 이런식으로 나타남.
-해결방법: 기존에 로그인클라 멤버변수로 갖고 있던 rooby_cnt를 총 서버에 접속한 플레이어 수를 세주는  Cnt_Player와 같이 네트워크 전역변수로 선언하여 extern으로 관리